### PR TITLE
fix: prevent open redirect via partial host matching in ParseRedirectURI

### DIFF
--- a/service/auth.go
+++ b/service/auth.go
@@ -183,7 +183,7 @@ func (s *Service) ParseRedirectURI(rawurl string) (*url.URL, error) {
 	}
 
 	for _, origin := range s.AllowedOrigins {
-		if strings.Contains(origin, uri.Host) {
+		if uri.Host == origin || strings.HasSuffix(uri.Host, "."+origin) {
 			return uri, nil
 		}
 	}


### PR DESCRIPTION
## Summary

Fix an open redirect vulnerability in `ParseRedirectURI` caused by partial host matching.

## Problem

The current allowed-origins check uses `strings.Contains(origin, uri.Host)`, which performs a **substring match** instead of an exact host comparison. This means a redirect URI with a host that is a substring of any allowed origin will pass validation.

For example, if `AllowedOrigins` contains `"trusted.example.com"`:
- A redirect to `https://trusted/evil` would pass (since `"trusted"` is contained in `"trusted.example.com"`)
- A redirect to `https://example/phish` would also pass

This enables open redirect attacks, which can be chained with OAuth flows or magic link authentication to steal tokens.

## Fix

Replace `strings.Contains(origin, uri.Host)` with exact host matching + subdomain matching via `strings.HasSuffix`, consistent with the existing `s.Origin.Host` check on line 181:

```go
// Before (vulnerable)
if strings.Contains(origin, uri.Host) {

// After (safe)
if uri.Host == origin || strings.HasSuffix(uri.Host, "."+origin) {
```

This ensures:
- Exact match: `uri.Host == origin` — the redirect host must match an allowed origin exactly
- Subdomain match: `strings.HasSuffix(uri.Host, "."+origin)` — subdomains of allowed origins are permitted (matching the existing pattern used for `s.Origin.Host`)

## Impact

- **Type**: Open Redirect (CWE-601)
- **Affected function**: `service.(*Service).ParseRedirectURI`
- **Risk**: Token theft via redirect in magic link / OAuth flows